### PR TITLE
bugfix/accurics_remediation_4932103033459907 - Auto Generated Pull Request From Accurics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,10 +3,11 @@ provider "aws" {
 }
 
 resource "aws_ami" "awsAmiEncrypted" {
-  name                = "some-name"
+  name = "some-name"
 
   ebs_block_device {
     device_name = "dev-name"
-    encrypted = var.enc
+    encrypted   = var.enc
   }
+  encrypted = true
 }


### PR DESCRIPTION
AMIs that are backed by Amazon EBS snapshots can take advantage of Amazon EBS encryption. Snapshots of both data and root volumes can be encrypted and attached to an AMI. You can launch instances and copy images with full EBS encryption support included. Encryption parameters for these operations are supported in all Regions where AWS KMS is available.